### PR TITLE
Issue #37 - translate the english idioms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,41 @@
   - Google
   - Bing
   - DeepL
+  - Amazon
   - Baidu
   - Youdao
   - Oxford Dictionary
   - Marriam Webster
-  - Amazon
   - Urban Dictionary
 
 ### Known Issues
 
+* operation
   - http2 connection reuse for api
+  - aws route53 area dns response, china and nz and aus multi-az load balance
+  - detect the network error and notify the user
   - build analysis
   - uglify the secret
-  - aws route53 area dns response, china and nz and aus multi-az load balance
+  - threshold and debounce in input suggestion
   - test case
       - test the method
-  - me
-      - dictionary translation
-      - maccaury for austrailia english
-      - cambridge
-      - langdao
-      - langman
-      - kolin dictionary
-      - macmillan
-      - translation for english(click and load)
-      - threshold and debounce in input suggestion
-      - url link contains word
+
+* translation source
+  - dictionary translation
+  - maccaury for austrailia english
+  - cambridge
+  - langdao
+  - langman
+  - kolin dictionary
+  - macmillan
+
+* user experience
+  - loading icon
+  - url link contains word
+  - input box default stay center
+  - input box can become textarea
   - dictionary content:
       - the sauruslinks
       - cross reference
-  - chenyi:
-      - input box default stay center
-  - huning
-      - input box can become textarea
       - example website
-  - detect the network error and notify the user
-  - loading icon
-  - split the english to english into 2 part, 1 part support sentence translation
+      - translation for english(click and load)

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -78,11 +78,13 @@ export default class Input extends Component {
         this.props.youdaoTranslate(inputData);
         this.props.bingTranslate(inputData);
         this.props.amazonTranslate(inputData);
-        if (inputData.isEnglish && !inputData.isSentence) {
+        if (inputData.isEnglish) {
             this.props.urbanTranslate(inputData);
             this.props.oxfordTranslate(inputData);
             this.props.oxfordFetchExamples(inputData);
-            this.props.websterTranslate(inputData);
+            if (!inputData.isSentence) {
+                this.props.websterTranslate(inputData);
+            }
         } else {
             this.props.cleanEnEnResult();
         }
@@ -91,6 +93,12 @@ export default class Input extends Component {
 
     handleKeyDown = (event) => {
         if(event.key === "Enter") this.handleClick();
+    }
+
+    onFocus = (event) => {
+        event.target.select();
+        // Below line is for iOS mobile device
+        event.target.setSelectionRange(0, 9999);
     }
 
     render() {
@@ -106,7 +114,8 @@ export default class Input extends Component {
                         placeholder="translate word or sentence for english and mandarin..."
                         onChange={this.handleChange}
                         onKeyDown={this.handleKeyDown}
-                        onFocus={event => event.target.select()}
+                        onMouseUp={event => event.preventDefault()}
+                        onFocus={this.onFocus}
                         defaultValue={this.state.matchedOption}
                         key={this.state.matchedOption}
                     />


### PR DESCRIPTION
        1. Oxford and Urban Dictionary can translate the english phrase
        2. iOS mobile browser can automatically select all of the text
        when touch it.
        3. Safari can select all the input text when click it by disable
        the default onMouseUp event behaviour.
        4. Update the TODO list